### PR TITLE
Make the QueryClosest function handle the empty case.  Prior to this …

### DIFF
--- a/Assets/Datastructures/KDTree/KDQuery/QueryClosest.cs
+++ b/Assets/Datastructures/KDTree/KDQuery/QueryClosest.cs
@@ -38,6 +38,10 @@ namespace DataStructures.ViliWonka.KDTree {
             Vector3[] points = tree.Points;
             int[] permutation = tree.Permutation;
 
+            if (points.Length == 0) {
+                return;
+            }
+
             int smallestIndex = 0;
             /// Smallest Squared Radius
             float SSR = Single.PositiveInfinity;


### PR DESCRIPTION
…fix, it would erroneously tell you index 0 was the closest