### PR TITLE
Make the QueryClosest function handle the empty case.

### DIFF
--- a/Assets/Datastructures/KDTree/KDQuery/QueryClosest.cs
+++ b/Assets/Datastructures/KDTree/KDQuery/QueryClosest.cs
@@ -35,6 +35,10 @@ namespace DataStructures.ViliWonka.KDTree {
 
             Reset();
 
+            if (points.Count == 0) {
+                return;
+            }
+
             Vector3[] points = tree.Points;
             int[] permutation = tree.Permutation;
 


### PR DESCRIPTION
Prior to this fix, it would erroneously tell you index 0 was the closest